### PR TITLE
Test snippets

### DIFF
--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -40,6 +40,8 @@ jobs:
           command: install
           args: mdbook-linkcheck
 
+      - run: mdbook test site
+
       - run: mdbook build site
 
       - name: Deploy

--- a/site/book.toml
+++ b/site/book.toml
@@ -6,6 +6,9 @@ language = "en"
 multilingual = false
 src = "src"
 
+[rust]
+edition = "2021"
+
 [build]
 create-missing = false
 

--- a/site/src/code-discipline.md
+++ b/site/src/code-discipline.md
@@ -7,7 +7,7 @@ By maximising the use of `Self` it also highlights where it _isn’t_ possible t
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 impl Node {
     pub fn new(parent: &Self) -> Self {
         Self(..)
@@ -21,7 +21,7 @@ impl PartialOrd for Node {
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 impl Node {
     pub fn new(parent: &Node) -> Node {
         Foo(..)
@@ -47,7 +47,7 @@ In this case, it is okay to use the crate’s `Result` type alias instead.
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 impl Responder for MyType {
     type Response = SomeStruct;
     type Err = Error;
@@ -63,7 +63,7 @@ impl Responder for MyType {
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 impl Responder for MyType {
     type Response = SomeStruct;
     type Err = Error;
@@ -105,7 +105,7 @@ If there is a dependency between field declarations, for example if some shared 
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 struct Entry<K, V> {
     id: u64,
     key: K,
@@ -129,7 +129,7 @@ fn get_entry(&self, key: K) -> Result<Entry<K, V>> {
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 struct Entry<K, V> {
     id: u64,
     key: K,
@@ -156,7 +156,7 @@ Keep things visually simple—if the formatter chooses to break tuple population
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 let key = some_long_computation()?
     .something_else()
     .another_thing();
@@ -167,7 +167,7 @@ let value = some_other_long_computation()
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 (
     some_long_computation()?
         .something_else()
@@ -185,7 +185,7 @@ Prefer the latter as this makes the order of operations the same as what is read
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 let my_vec: Vec<_> = collection.into_iter()
     .filter(...)
     .collect();
@@ -193,7 +193,7 @@ let my_vec: Vec<_> = collection.into_iter()
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 let my_vec = Vec::from_iter(collection.into_iter().filter(...))
 ```
 
@@ -206,13 +206,13 @@ Consider also that `vec![expr; n]` where `n` is zero will still evaluate (and th
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 let my_vec = Vec::new();
 ```
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 let my_vec = vec![];
 let my_vec = Vec::with_capacity(0);
 ```
@@ -223,7 +223,7 @@ In many cases, mutability is used to create a given structure which is then used
 Whenever this happens, scope the mutable declarations to just where they are needed, thus forcing a compiler error if this condition is broken in future.
 Doing this also makes code simpler to read as there are fewer things which can mutate at any one point.
 
-```rust
+```rust,ignore
 let my_structure = {
     let mut my_structure = MyStructure::new();
     // Mutate `my_structure` as required to construct it.
@@ -236,7 +236,7 @@ For greatest clarity, make sure the name of the outer (immutable) and inner (mut
 If mutability is to retain some state whilst iterating through a structure, consider using a functional style instead.
 As a simple example, if presented with the following imperative code to count the number of spaces in a string
 
-```rust
+```rust,ignore
 let mut num_spaces = 0;
 for c in my_string.chars() {
     if c == ' ' {
@@ -247,7 +247,7 @@ for c in my_string.chars() {
 
 Consider instead, using the functional style to avoid the mutation—
 
-```rust
+```rust,ignore
 let num_spaces = my_string.chars()
     .filter(|c| c == ' ')
     .count();
@@ -260,7 +260,7 @@ Instead, prefer to return the required value from the block which computes it.
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 let message = if result.is_ok() {
     "success!"
 } else {
@@ -285,7 +285,7 @@ let message = loop {
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 let message;
 if result.is_ok() {
     message = "success!";
@@ -324,14 +324,14 @@ As a rule of thumb, only use `&` at the start of the value of a `let` declaratio
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 let foo = from_func();
 other_func(&foo);
 ```
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 let foo = &from_func();
 other_func(foo);
 ```
@@ -348,7 +348,7 @@ Let us consider name-shadowing with variables, for which there are three cases:
 
 In the first case when shadowing with different scopes, use at most one level of shadowing, for example when pattern matching enum variants—
 
-```rust
+```rust,ignore
 if let Some(foo) = foo {
     // The outer `foo` is now shadowed.
     // The inner `foo` should not be shadowed.
@@ -358,7 +358,7 @@ if let Some(foo) = foo {
 In the second case when shadowing in the same scope with the same type, there is no restriction placed on this and it may be done as many times as necessary.
 However, if this is being used to effectively mutate a value during construction with no other values being affected, instead use the scoped-mutability pattern—
 
-```rust
+```rust,ignore
 let my_thing = {
     let mut my_thing = ...;
     // Mutate `my_thing` to construct it...
@@ -369,7 +369,7 @@ let my_thing = {
 In the final case, when shadowing in the same but changing types (e.g. in a conversion method), shadowing can be done at most once per variable.
 This pattern is commonly seen in conversion functions—those which take ownership of their sole parameter and convert it into another type.
 
-```rust
+```rust,ignore
 impl Store<New> {
     fn init(self) -> Store<Inited> {
         let Self { some_field } = self,
@@ -401,7 +401,7 @@ These rules ensure that the reader cannot miss any constraints.
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 impl<'a, 'b, I, T> SomeStruct<'a, 'b, I, T>
     where
         'b: 'a,
@@ -412,7 +412,7 @@ impl<'a, 'b, I, T> SomeStruct<'a, 'b, I, T>
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 impl<'a, 'b: 'a, I: IntoIterator<T> + 'a> SomeStruct
     where
         T: 'b
@@ -458,7 +458,7 @@ If a type parameter seems necessary as a variable name is not sufficiently descr
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 let some_meaningful_var_name: Vec<_> = foo.iter()
     .filter(...)
     .map(...)
@@ -468,7 +468,7 @@ let some_meaningful_var_name: Vec<_> = foo.iter()
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 let x = foo.iter()
     .filter(...)
     .map(...)
@@ -486,7 +486,7 @@ If a single value is to be ignored, use the ‘toilet operator,’ `|_| ()`, i.e
 a closure which takes one argument, ignores it and returns a unit.
 This form is consistent with similar closures which ignore parts of their inputs, for example when extracting the key from a key-value pair—
 
-```rust
+```rust,ignore
     .map(|(key, _)| key)
 ```
 
@@ -499,7 +499,7 @@ This highlights that we care only about side-effects, and that no information is
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 async fn log(&self, message: String) -> Result<()> {
     {
         let mut file = OpenOptions::new()
@@ -514,7 +514,7 @@ async fn log(&self, message: String) -> Result<()> {
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 async fn log(&self, message: String) -> Result<()> {
     let mut file = OpenOptions::new()
         .append(true)
@@ -557,7 +557,7 @@ To nicely transfer data from some remote format into one we govern, say `ImageIn
 Add a comment which says `// serde types.` to let the reader know that everything beyond this point only relates to modelling the remote API—thus saving them time as they will likely only care about these details if something is broken.
 Add as many new local types as are necessary to maintain a 1:1 relationship between Rust types and the remote’s format—
 
-```rust
+```rust,ignore
 async fn get_image_info(&self, name: &str) -> Result<ImageInfo> {
     let response: Response = serde_json::from_str(get_response(...).await?.text());
     let info = ImageInfo {
@@ -604,7 +604,7 @@ Expressions which end in a `)` or `]` follow the same rule unless that expressio
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 foo(FooConfig {
     bar: "asdf",
     baz: "fdsa",
@@ -627,7 +627,7 @@ value.to_string()
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 Foo {
     bar: "asdf",
     baz: "fdsa",
@@ -655,12 +655,12 @@ _NB: older Rust versions may not support this syntax._
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 format!("{path}/{file}")
 ```
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 format!("{}/{}", path, file)
 ```

--- a/site/src/code-discipline.md
+++ b/site/src/code-discipline.md
@@ -519,7 +519,7 @@ These rules ensure that the reader cannot miss any constraints.
 ✅ Do this:
 
 ```rust
-# struct IterWrapper<I>(std::marker::PhantomData<I>);
+# struct IterWrapper<I>(I);
 impl<'a, 'b, I, T> IterWrapper<I>
     where
         'b: 'a,
@@ -531,7 +531,7 @@ impl<'a, 'b, I, T> IterWrapper<I>
 ⚠️ Avoid this:
 
 ```rust
-# struct IterWrapper<I>(std::marker::PhantomData<I>);
+# struct IterWrapper<I>(I);
 impl<'a, 'b: 'a, I: Iterator<Item=T> + 'a, T> IterWrapper<I>
     where
         T: 'b
@@ -592,7 +592,7 @@ let some_meaningful_var_name: Vec<_> = foo.iter()
 
 ```rust
 # fn snippet<'lifetimes, With, Generics>() {
-# struct And<'l>(std::marker::PhantomData<&'l ()>);
+# struct And<'l>(&'l ());
 # let foo = [0];
 # let filter_closure = |_: &&i32| true;
 # let map_closure = |x| SomeExtremelyLongType(std::marker::PhantomData);

--- a/site/src/code-discipline.md
+++ b/site/src/code-discipline.md
@@ -7,29 +7,44 @@ By maximising the use of `Self` it also highlights where it _isn’t_ possible t
 
 ✅ Do this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/code_discipline.rs}}
+# use std::cmp::Ordering;
+# #[derive(Eq, PartialEq)]
+# struct Node;
 impl Node {
     pub fn new(parent: &Self) -> Self {
-        Self(..)
+        // ...
+#       Node
     }
 }
 
 impl PartialOrd for Node {
-    fn cmp(&self, other: &Self) -> Ordering;
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+#       Some(Ordering::Less)
+    }
 }
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/code_discipline.rs}}
+# use std::cmp::Ordering;
+# #[derive(Eq, PartialEq)]
+# struct Node;
 impl Node {
     pub fn new(parent: &Node) -> Node {
-        Foo(..)
+        // ...
+#       Node
     }
 }
 
-impl PartialOrd<Rhs=Node> for Node { // NB: Rhs=Self is also the default for PartialOrd.
-    fn cmp(&self, other: &Node) -> Ordering;
+impl PartialOrd<Node> for Node { // NB: Rhs=Self is also the default for PartialOrd.
+    fn partial_cmp(&self, other: &Node) -> Option<Ordering> {
+        // ...
+#       Some(Ordering::Less)
+    }
 }
 ```
 
@@ -47,15 +62,23 @@ In this case, it is okay to use the crate’s `Result` type alias instead.
 
 ✅ Do this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/code_discipline.rs}}
+# type MyType = Arbitrary;
+# struct SomeStruct {
+#     some: (),
+#     fields: (),
+# }
 impl Responder for MyType {
     type Response = SomeStruct;
     type Err = Error;
 
     fn respond(&self, _input: Input) -> Result<Self::Response> {
+        let some = ();
+        let fields = ();
         Ok(SomeStruct{
-            some: ...,
-            fields: ...,
+            some,
+            fields,
         })
     }
 }
@@ -63,18 +86,29 @@ impl Responder for MyType {
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/code_discipline.rs}}
+# type MyType = Arbitrary;
+# struct SomeStruct {
+#     some: (),
+#     fields: (),
+# }
+# {
+# type Result<T, E> = std::result::Result<T, E>;
 impl Responder for MyType {
     type Response = SomeStruct;
     type Err = Error;
 
-    fn respond(&self, _input: I) -> Result<SomeStruct, Error> {
+    fn respond(&self, _input: Input) -> Result<SomeStruct, Error> {
+        let some = ();
+        let fields = ();
         Ok(Self::Response {
-            some: ...,
-            fields: ...,
+            some,
+            fields,
         })
     }
 }
+# }
 ```
 
 ## Struct population
@@ -105,7 +139,8 @@ If there is a dependency between field declarations, for example if some shared 
 
 ✅ Do this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/code_discipline.rs}}
 struct Entry<K, V> {
     id: u64,
     key: K,
@@ -113,23 +148,40 @@ struct Entry<K, V> {
     pretty_date_modified: String,
 }
 
-fn get_entry(&self, key: K) -> Result<Entry<K, V>> {
-    let id = self.id_of(key)?;
-    let value = self.get(key)?;
-    let pretty_date_modified = self.date_modified(key)?
+# type V = Arbitrary;
+# impl<K: Clone> Entry<K, V> {
+fn get_entry(&self, key: &K) -> Result<Entry<K, V>> {
+    let key = key.clone();
+    let id = self.id_of(&key)?;
+    let value = self.get(&key)?;
+    let pretty_date_modified = self.date_modified(&key)?
         .format_as("yyyy-MM-dd@hh:mm:ss");
-    Entry {
+    Ok(Entry {
         id,
         key,
         value,
         pretty_date_modified,
-    }
+    })
 }
+#
+#   fn get(&self, _: &K) -> Result<V> {
+#       Ok(Arbitrary)
+#   }
+#
+#   fn id_of(&self, _: &K) -> Result<u64> {
+#       Ok(0)
+#   }
+#
+#   fn date_modified(&self, _: &K) -> Result<Arbitrary> {
+#       Ok(Arbitrary)
+#   }
+# }
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/code_discipline.rs}}
 struct Entry<K, V> {
     id: u64,
     key: K,
@@ -137,16 +189,31 @@ struct Entry<K, V> {
     pretty_date_modified: String,
 }
 
-fn get_entry(&self, key: K) -> Result<Entry<K, V>> {
+# type V = Arbitrary;
+# impl<K: Clone> Entry<K, V> {
+fn get_entry(&self, key: &K) -> Result<Entry<K, V>> {
     let value_stored_at_key = self.get(key)?;
-    Entry {
+    Ok(Entry {
         id: self.id_of(key)?,
         pretty_date_modified: self.date_modified(key)?
             .format_as("yyyy-MM-dd@hh:mm:ss"),
-        key,
+        key: key.clone(),
         value: value_stored_at_key,
-    }
+    })
 }
+#
+#   fn get(&self, _: &K) -> Result<V> {
+#       Ok(Arbitrary)
+#   }
+#
+#   fn id_of(&self, _: &K) -> Result<u64> {
+#       Ok(0)
+#   }
+#
+#   fn date_modified(&self, _: &K) -> Result<Arbitrary> {
+#       Ok(Arbitrary)
+#   }
+# }
 ```
 
 ## Tuple population
@@ -157,17 +224,26 @@ Keep things visually simple—if the formatter chooses to break tuple population
 ✅ Do this:
 
 ```rust,ignore
+{{#include snippet_helpers/code_discipline.rs}}
+# fn snippet() -> Result<(Arbitrary, Arbitrary)> {
 let key = some_long_computation()?
     .something_else()
     .another_thing();
 let value = some_other_long_computation()
     .chained_with_something_else()?;
+# let ret =
 (key, value)
+# ;
+# Ok(ret)
+# }
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/code_discipline.rs}}
+# fn snippet() -> Result<(Arbitrary, Arbitrary)> {
+# let ret =
 (
     some_long_computation()?
         .something_else()
@@ -175,6 +251,9 @@ let value = some_other_long_computation()
     some_other_long_computation()
         .chained_with_something_else()?,
 )
+# ;
+# Ok(ret)
+# }
 ```
 
 ## Prefer `collect` when interacting with `FromIterator`
@@ -185,16 +264,23 @@ Prefer the latter as this makes the order of operations the same as what is read
 
 ✅ Do this:
 
-```rust,ignore
+```rust
+# let collection = [0];
+# let filter_closure = |_: &i32| true;
 let my_vec: Vec<_> = collection.into_iter()
-    .filter(...)
+    .filter(filter_closure)
     .collect();
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
-let my_vec = Vec::from_iter(collection.into_iter().filter(...))
+```rust
+# let collection = [0];
+# let filter_closure = |_: &i32| true;
+let my_vec = Vec::from_iter(
+    collection.into_iter()
+        .filter(filter_closure)
+);
 ```
 
 ## Empty `Vec` construction
@@ -206,15 +292,18 @@ Consider also that `vec![expr; n]` where `n` is zero will still evaluate (and th
 
 ✅ Do this:
 
-```rust,ignore
+```rust
 let my_vec = Vec::new();
+# let my_vec_constraint: Vec<i32> = my_vec;
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
 let my_vec = vec![];
+# let my_vec_constraint: Vec<i32> = my_vec;
 let my_vec = Vec::with_capacity(0);
+# let my_vec_constraint: Vec<i32> = my_vec;
 ```
 
 ## Avoid loosely-scoped `let mut`
@@ -223,7 +312,9 @@ In many cases, mutability is used to create a given structure which is then used
 Whenever this happens, scope the mutable declarations to just where they are needed, thus forcing a compiler error if this condition is broken in future.
 Doing this also makes code simpler to read as there are fewer things which can mutate at any one point.
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/code_discipline.rs}}
+# type MyStructure = Arbitrary;
 let my_structure = {
     let mut my_structure = MyStructure::new();
     // Mutate `my_structure` as required to construct it.
@@ -236,20 +327,22 @@ For greatest clarity, make sure the name of the outer (immutable) and inner (mut
 If mutability is to retain some state whilst iterating through a structure, consider using a functional style instead.
 As a simple example, if presented with the following imperative code to count the number of spaces in a string
 
-```rust,ignore
+```rust
+# let my_string = "";
 let mut num_spaces = 0;
 for c in my_string.chars() {
     if c == ' ' {
-        num_speces += 1;
+        num_spaces += 1;
     }
 }
 ```
 
 Consider instead, using the functional style to avoid the mutation—
 
-```rust,ignore
+```rust
+# let my_string = "";
 let num_spaces = my_string.chars()
-    .filter(|c| c == ' ')
+    .filter(|c| *c == ' ')
     .count();
 ```
 
@@ -260,13 +353,17 @@ Instead, prefer to return the required value from the block which computes it.
 
 ✅ Do this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/code_discipline.rs}}
+# fn snippet() -> Result<()> {
+# let result = Result::Ok(());
 let message = if result.is_ok() {
     "success!"
 } else {
     "failed!"
-}
+};
 
+# fn exec_web_request() -> Result<Message> { Ok(Message) }
 let mut retries = 0;
 let message = loop {
     let resp = exec_web_request();
@@ -278,14 +375,19 @@ let message = loop {
 
     retries += 1;
     if retries > 5 {
-        return Err(Error::Unavailable);
+        return Err(Error::NetworkUnavailable);
     }
-}
+};
+# Ok(())
+# }
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/code_discipline.rs}}
+# fn snippet() -> Result<()> {
+# let result = Result::Ok(());
 let message;
 if result.is_ok() {
     message = "success!";
@@ -293,6 +395,7 @@ if result.is_ok() {
     message = "failed!";
 }
 
+# fn exec_web_request() -> Result<Message> { Ok(Message) }
 let mut retries = 0;
 let message;
 loop {
@@ -308,9 +411,11 @@ loop {
 
     retries += 1;
     if retries > 5 {
-        return Err(Error::Unavailable);
+        return Err(Error::NetworkUnavailable);
     }
 }
+# Ok(())
+# }
 ```
 
 ## Reference scope
@@ -324,14 +429,18 @@ As a rule of thumb, only use `&` at the start of the value of a `let` declaratio
 
 ✅ Do this:
 
-```rust,ignore
+```rust
+# fn from_func() {}
+# fn other_func(_: &()) {}
 let foo = from_func();
 other_func(&foo);
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
+# fn from_func() {}
+# fn other_func(_: &()) {}
 let foo = &from_func();
 other_func(foo);
 ```
@@ -348,7 +457,8 @@ Let us consider name-shadowing with variables, for which there are three cases:
 
 In the first case when shadowing with different scopes, use at most one level of shadowing, for example when pattern matching enum variants—
 
-```rust,ignore
+```rust
+let foo = Some(());
 if let Some(foo) = foo {
     // The outer `foo` is now shadowed.
     // The inner `foo` should not be shadowed.
@@ -358,9 +468,11 @@ if let Some(foo) = foo {
 In the second case when shadowing in the same scope with the same type, there is no restriction placed on this and it may be done as many times as necessary.
 However, if this is being used to effectively mutate a value during construction with no other values being affected, instead use the scoped-mutability pattern—
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/code_discipline.rs}}
+# type MyThing = Arbitrary;
 let my_thing = {
-    let mut my_thing = ...;
+    let mut my_thing = MyThing::new();
     // Mutate `my_thing` to construct it...
     my_thing
 };
@@ -369,17 +481,22 @@ let my_thing = {
 In the final case, when shadowing in the same but changing types (e.g. in a conversion method), shadowing can be done at most once per variable.
 This pattern is commonly seen in conversion functions—those which take ownership of their sole parameter and convert it into another type.
 
-```rust,ignore
+```rust
+# struct Store<S> {
+#     some_field: (),
+#     state: S,
+# }
+# struct New;
+# struct Inited;
 impl Store<New> {
     fn init(self) -> Store<Inited> {
-        let Self { some_field } = self,
-        // ...
+        let Self { some_field, .. } = self;
         let some_field = some_field.into();
         // ...
-        InitedSelf {
+        Store {
+            some_field,
             // ...
-            some_field
-            // ...
+#           state: Inited,
         }
     }
 }
@@ -401,22 +518,24 @@ These rules ensure that the reader cannot miss any constraints.
 
 ✅ Do this:
 
-```rust,ignore
-impl<'a, 'b, I, T> SomeStruct<'a, 'b, I, T>
+```rust
+# struct IterWrapper<I>(std::marker::PhantomData<I>);
+impl<'a, 'b, I, T> IterWrapper<I>
     where
         'b: 'a,
-        I: IntoIterator<T> + 'a,
+        I: Iterator<Item=T> + 'a,
         T: 'b,
-{ ... }
+{ /* ... */ }
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
-impl<'a, 'b: 'a, I: IntoIterator<T> + 'a> SomeStruct
+```rust
+# struct IterWrapper<I>(std::marker::PhantomData<I>);
+impl<'a, 'b: 'a, I: Iterator<Item=T> + 'a, T> IterWrapper<I>
     where
         T: 'b
-{ ... }
+{ /* ... */ }
 ```
 
 ## Type annotations
@@ -458,22 +577,32 @@ If a type parameter seems necessary as a variable name is not sufficiently descr
 
 ✅ Do this:
 
-```rust,ignore
+```rust
+# let foo = [0];
+# let filter_closure = |_: &&i32| true;
+# let map_closure = |_| ();
 let some_meaningful_var_name: Vec<_> = foo.iter()
-    .filter(...)
-    .map(...)
+    .filter(filter_closure)
+    .map(map_closure)
     // ...
     .collect();
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
+# fn snippet<'lifetimes, With, Generics>() {
+# struct And<'l>(std::marker::PhantomData<&'l ()>);
+# let foo = [0];
+# let filter_closure = |_: &&i32| true;
+# let map_closure = |x| SomeExtremelyLongType(std::marker::PhantomData);
+# struct SomeExtremelyLongType<W, G, A>(std::marker::PhantomData<(W, G, A)>);
 let x = foo.iter()
-    .filter(...)
-    .map(...)
+    .filter(filter_closure)
+    .map(map_closure)
     // ...
     .collect::<Vec<SomeExtremelyLongType<With, Generics, And<'lifetimes>>>>();
+# }
 ```
 
 ## Avoid explicit `drop` calls
@@ -486,8 +615,10 @@ If a single value is to be ignored, use the ‘toilet operator,’ `|_| ()`, i.e
 a closure which takes one argument, ignores it and returns a unit.
 This form is consistent with similar closures which ignore parts of their inputs, for example when extracting the key from a key-value pair—
 
-```rust,ignore
+```rust
+# [(1, 2)].iter()
     .map(|(key, _)| key)
+# ;
 ```
 
 There are two exceptions to this.
@@ -499,7 +630,11 @@ This highlights that we care only about side-effects, and that no information is
 
 ✅ Do this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/code_discipline.rs}}
+# use std::fs::OpenOptions;
+# use std::io::Write;
+# impl Log {
 async fn log(&self, message: String) -> Result<()> {
     {
         let mut file = OpenOptions::new()
@@ -507,24 +642,30 @@ async fn log(&self, message: String) -> Result<()> {
             .open(&self.log_file_path)?;
         file.write_all(message.as_bytes())?;
     }
-    self.transmit_log(message).await?;
+    self.transmit_log(&message).await?;
     Ok(())
 }
+# }
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/code_discipline.rs}}
+# use std::fs::OpenOptions;
+# use std::io::Write;
+# impl Log {
 async fn log(&self, message: String) -> Result<()> {
     let mut file = OpenOptions::new()
         .append(true)
         .open(&self.log_file_path)?;
     file.write_all(message.as_bytes())?;
     drop(file);
-    Ok(self.transmit_log(message)
+    self.transmit_log(&message)
         .await
-        .map(drop))
+        .map(drop)
 }
+# }
 ```
 
 ## Constructors vs. structs with all fields public
@@ -559,9 +700,9 @@ Add as many new local types as are necessary to maintain a 1:1 relationship betw
 
 ```rust,ignore
 async fn get_image_info(&self, name: &str) -> Result<ImageInfo> {
-    let response: Response = serde_json::from_str(get_response(...).await?.text());
+    let response: Response = serde_json::from_str(get_response().await?.text());
     let info = ImageInfo {
-        name,
+        name: name.to_owned(),
         version: response.metadata.version,
         authors: response.metadata.authors,
         latest_release: response.releases.last()
@@ -604,46 +745,82 @@ Expressions which end in a `)` or `]` follow the same rule unless that expressio
 
 ✅ Do this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/code_discipline.rs}}
+# fn snippet() -> Result<()> {
+# struct FooConfig {
+#     bar: &'static str,
+#     baz: &'static str,
+# }
+# fn foo(_: FooConfig) -> Result<()> {
+#     Ok(())
+# }
 foo(FooConfig {
     bar: "asdf",
     baz: "fdsa",
 })?;
 
+# let some_condition = true;
+# let value_a = "";
+# let value_b = "";
 let value = if some_condition {
     value_a
 } else {
-    value b
+    value_b
 };
 value.to_string()
+# ;
 
 // ...
+# ['?'].iter()
     .filter(|c| {
-        let exceptions = [ 'a', 'b', 'c', 'd', ... ];
+        let exceptions = [ 'a', 'b', 'c', 'd' ];
         !exceptions.contains(c)
     })
+# ;
 // ...
+# Ok(())
+# }
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/code_discipline.rs}}
+# fn snippet() -> Result<()> {
+# struct Foo {
+#     bar: &'static str,
+#     baz: &'static str,
+# }
+# impl Foo {
+#     fn do_thing(self) -> Result<()> {
+#         Ok(())
+#     }
+# }
 Foo {
     bar: "asdf",
     baz: "fdsa",
 }
 .do_thing()?;
 
+# let some_condition = true;
+# let value_a = "";
+# let value_b = "";
 if some_condition {
     value_a
 } else {
     value_b
 }
 .to_string()
+# ;
 
 // ...
-    .filter(|c| ![ 'a', 'b', 'c', 'd', ... ].contains(c))
+# ['?'].iter()
+    .filter(|c| ![ 'a', 'b', 'c', 'd' ].contains(c))
+# ;
 // ...
+# Ok(())
+# }
 ```
 
 ## Format arg inlining
@@ -655,12 +832,18 @@ _NB: older Rust versions may not support this syntax._
 
 ✅ Do this:
 
-```rust,ignore
+```rust
+# let path = "";
+# let file = "";
 format!("{path}/{file}")
+# ;
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
+# let path = "";
+# let file = "";
 format!("{}/{}", path, file)
+# ;
 ```

--- a/site/src/code-discipline.md
+++ b/site/src/code-discipline.md
@@ -223,7 +223,7 @@ Keep things visually simple—if the formatter chooses to break tuple population
 
 ✅ Do this:
 
-```rust,ignore
+```rust
 {{#include snippet_helpers/code_discipline.rs}}
 # fn snippet() -> Result<(Arbitrary, Arbitrary)> {
 let key = some_long_computation()?

--- a/site/src/comment-discipline.md
+++ b/site/src/comment-discipline.md
@@ -8,7 +8,7 @@ After reading this first sentence, it should be clear _when_ to use the given fu
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 /// This function reports an increase in the number of steps taken by this
 /// thread.
 fn add_steps(&self, delta: i64) -> Result<()> { .. }
@@ -16,7 +16,7 @@ fn add_steps(&self, delta: i64) -> Result<()> { .. }
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 /// This function adds a given delta to the current step counter.
 fn add_steps(&self, delta: i64) -> Result<()> { .. }
 ```
@@ -29,14 +29,14 @@ Leave no room for ambiguity and hence misunderstanding.
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 /// Increments this counter by the given `delta`.
 fn incr_by(&self, delta: u64) -> Result<()> { .. }
 ```
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 /// Increments a counter by a given amount.
 fn incr_by(&self, delta: u64) -> Result<()> { .. }
 ```

--- a/site/src/comment-discipline.md
+++ b/site/src/comment-discipline.md
@@ -8,17 +8,29 @@ After reading this first sentence, it should be clear _when_ to use the given fu
 
 ✅ Do this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/comment_discipline.rs}}
+# impl Arbitrary {
 /// This function reports an increase in the number of steps taken by this
 /// thread.
-fn add_steps(&self, delta: i64) -> Result<()> { .. }
+fn add_steps(&self, delta: i64) -> Result<()> {
+    /* ... */
+#   Ok(())
+}
+# }
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/comment_discipline.rs}}
+# impl Arbitrary {
 /// This function adds a given delta to the current step counter.
-fn add_steps(&self, delta: i64) -> Result<()> { .. }
+fn add_steps(&self, delta: i64) -> Result<()> {
+    /* ... */
+#   Ok(())
+}
+# }
 ```
 
 ## Definite vs. Indefinite articles
@@ -29,14 +41,26 @@ Leave no room for ambiguity and hence misunderstanding.
 
 ✅ Do this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/comment_discipline.rs}}
+# impl Arbitrary {
 /// Increments this counter by the given `delta`.
-fn incr_by(&self, delta: u64) -> Result<()> { .. }
+fn incr_by(&self, delta: u64) -> Result<()> {
+    /* ... */
+#   Ok(())
+}
+# }
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/comment_discipline.rs}}
+# impl Arbitrary {
 /// Increments a counter by a given amount.
-fn incr_by(&self, delta: u64) -> Result<()> { .. }
+fn incr_by(&self, delta: u64) -> Result<()> {
+    /* ... */
+#   Ok(())
+}
+# }
 ```

--- a/site/src/cosmetic-discipline.md
+++ b/site/src/cosmetic-discipline.md
@@ -15,7 +15,9 @@ There are no hard and fast rules for this strong association, but the following 
 
 ✅ Do this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/cosmetic_discipline.rs}}
+# fn snippet() -> Result<Arbitrary> {
 let x = foo();
 if !x.is_valid() {
     return Err(Error::Invalid);
@@ -27,11 +29,14 @@ if !y.is_valid() {
     return Err(Error::Invalid);
 }
 return Ok(y);
+# }
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/cosmetic_discipline.rs}}
+# fn snippet() -> Result<Arbitrary> {
 let x = foo();
 
 if !x.is_valid() {
@@ -45,6 +50,7 @@ if !y.is_valid() {
 }
 
 return Ok(y);
+# }
 ```
 
 ## Grouping
@@ -63,26 +69,33 @@ _The following snippets assume that functions `foo`, `bar` and `baz` are free of
 
 ✅ Do this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/cosmetic_discipline.rs}}
+# fn snippet() -> Result<()> {
 let x = foo();
 let b = baz();
 if !b.is_valid() {
-    return Err(Error::Invalid)
+    return Err(Error::Invalid);
 }
 let z = x + b;
 
 let y = bar();
 if !y.is_valid() {
-    return Err(Error::Invalid)
+    return Err(Error::Invalid);
 }
+# Ok(())
+# }
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
-let x = foo()
-let check = |x| {
-    if !x.valid() {
+```rust
+{{#include snippet_helpers/cosmetic_discipline.rs}}
+# fn snippet() -> Result<()> {
+# type X = Arbitrary;
+let x = foo();
+let check = |x: X| {
+    if !x.is_valid() {
         return Err(Error::Invalid)
     }
     Ok(x)
@@ -90,6 +103,8 @@ let check = |x| {
 let y = bar();
 let z = x + check(baz())?;
 check(y)?;
+# Ok(())
+# }
 ```
 
 ## Hex values
@@ -99,12 +114,12 @@ By using lowercase, we provide more ‘handles’ for the eye to use.
 
 ✅ Do this:
 
-```rust,ignore
+```rust
 const SOME_SPECIFIC_IMPORTANT_VALUE: u64 = 0xab5c4d320974a3bc;
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
 const SOME_SPECIFIC_IMPORTANT_VALUE: u64 = 0xAB5C4D320974A3BC;
 ```

--- a/site/src/cosmetic-discipline.md
+++ b/site/src/cosmetic-discipline.md
@@ -15,7 +15,7 @@ There are no hard and fast rules for this strong association, but the following 
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 let x = foo();
 if !x.is_valid() {
     return Err(Error::Invalid);
@@ -31,7 +31,7 @@ return Ok(y);
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 let x = foo();
 
 if !x.is_valid() {
@@ -63,7 +63,7 @@ _The following snippets assume that functions `foo`, `bar` and `baz` are free of
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 let x = foo();
 let b = baz();
 if !b.is_valid() {
@@ -79,7 +79,7 @@ if !y.is_valid() {
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 let x = foo()
 let check = |x| {
     if !x.valid() {
@@ -99,12 +99,12 @@ By using lowercase, we provide more ‘handles’ for the eye to use.
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 const SOME_SPECIFIC_IMPORTANT_VALUE: u64 = 0xab5c4d320974a3bc;
 ```
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 const SOME_SPECIFIC_IMPORTANT_VALUE: u64 = 0xAB5C4D320974A3BC;
 ```

--- a/site/src/error-and-panic-discipline.md
+++ b/site/src/error-and-panic-discipline.md
@@ -9,13 +9,13 @@ Error messages should be concise.
 Every second longer a user spends reading an error message and not understanding what went wrong is a second longer of their frustration.
 The form of the phrases used in error messages should be consistent—if, likely from previous messages, the user is expecting—
 
-```
+```ignore
 cannot foo the bar
 ```
 
 but instead reads—
 
-```
+```ignore
 bar is not fooable
 ```
 
@@ -70,7 +70,7 @@ Errors which preserve types but which represent unrecoverable errors should repr
 When constructing these errors, special care must be taken to ensure that the message is consistent with other errors in the codebase.
 The field used to hold the reason for the error in these cases should be named `reason`.
 
-```rust
+```rust,ignore
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     // ...
@@ -85,7 +85,7 @@ pub enum Error {
 
 If one error wraps another, the inner error should be held in a field named `source`.
 
-```rust
+```rust,ignore
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     // ...
@@ -101,7 +101,7 @@ pub enum Error {
 Note that exposing the error type originating from dependencies as these may accidentally expose internal details in a public API.
 In these cases, if using enumerated errors, consider adding an `Internal` variant which holds a type which hides the internal details as follows—
 
-```rust
+```rust,ignore
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     // ...
@@ -129,7 +129,7 @@ By maintaining the same convention with short chains, our code becomes more pred
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 let override_url = env::var("URL")
     .ok()
     .map(|override| {
@@ -143,7 +143,7 @@ let override_url = env::var("URL")
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 let override_url = env::var("URL")
     .ok()
     .map(|override_url| url::Url::parse(&override_url))

--- a/site/src/error-and-panic-discipline.md
+++ b/site/src/error-and-panic-discipline.md
@@ -129,21 +129,30 @@ By maintaining the same convention with short chains, our code becomes more pred
 
 ✅ Do this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/error_and_panic_discipline.rs}}
+# fn snippet() -> Result<()> {
+# use std::env;
+# use url::Url;
 let override_url = env::var("URL")
     .ok()
-    .map(|override| {
-        Url::parse(&override).map_err(|source| Error::MalformedEnvUrl {
+    .map(|override_url| {
+        Url::parse(&override_url).map_err(|source| Error::MalformedEnvUrl {
             env_var: "URL",
             source,
         })
     })
     .transpose()?;
+# Ok(())
+# }
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/error_and_panic_discipline.rs}}
+# use std::env;
+# fn snippet() -> Result<()> {
 let override_url = env::var("URL")
     .ok()
     .map(|override_url| url::Url::parse(&override_url))
@@ -152,6 +161,8 @@ let override_url = env::var("URL")
         env_var: "URL",
         source,
     })?;
+# Ok(())
+# }
 ```
 
 ## Panic calmly

--- a/site/src/function-discipline.md
+++ b/site/src/function-discipline.md
@@ -156,24 +156,32 @@ In typical usage, users of `MyType` shouldn’t need to import `MyTypeBuilder`, 
 
 ✅ Do this:
 
-```rust,ignore
-use crate::Foo;
+```rust
+{{#include snippet_helpers/function_discipline.rs}}
+# fn snippet() -> std::result::Result<(), Box<dyn std::error::Error>> {
+use some_crate::Foo;
 
 let foo = Foo::builder()
     .foo("foo")
     .bar("bar")
     .build()?;
+# Ok(())
+# }
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
-use some_crate::{Foo, FooBuilder}
+```rust
+{{#include snippet_helpers/function_discipline.rs}}
+# fn snippet() -> std::result::Result<(), Box<dyn std::error::Error>> {
+use some_crate::{Foo, FooBuilder};
 
 let foo = FooBuilder::new()
     .foo("foo")
     .bar("bar")
     .build()?;
+# Ok(())
+# }
 ```
 
 ## Builder ownership

--- a/site/src/function-discipline.md
+++ b/site/src/function-discipline.md
@@ -18,27 +18,53 @@ Therefore, do-nothing `match` branches should be written as `.. => {}` rather th
 
 ✅ Do this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/function_discipline.rs}}
+# struct Foo {
+#     foo_type: FooType
+# }
+# enum FooType {
+#     A,
+# }
+# impl Foo {
 fn setup_foo(&self) -> Result<()> {
     match self.foo_type {
         FooType::A => {}
-        ...
+        // ...
     }
     self.setup_bar()?;
     Ok(())
 }
+#
+#   fn setup_bar(&self) -> Result<()> {
+#       Ok(())
+#   }
+# }
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/function_discipline.rs}}
+# struct Foo {
+#     foo_type: FooType
+# }
+# enum FooType {
+#     A,
+# }
+# impl Foo {
 fn setup_foo(&self) -> Result<()> {
     match self.foo_type {
         FooType::A => ()
-        ...
+        // ...
     }
     self.setup_bar()
 }
+#
+#   fn setup_bar(&self) -> Result<()> {
+#       Ok(())
+#   }
+# }
 ```
 
 ## Hide generic type parameters
@@ -58,14 +84,26 @@ If a lifetime is present, _always_ communicate that fact (i.e. always prefer `My
 
 ✅ Do this:
 
-```rust,ignore
-fn transmit(tx: impl Transmitter<'_>, message: &[u8]) -> Result<()> { ... }
+```rust
+{{#include snippet_helpers/function_discipline.rs}}
+# trait Transmitter {}
+# struct Message<'a>(&'a ());
+fn transmit(tx: impl Transmitter, message: &Message<'_>) -> Result<()> {
+    // ...
+#   Ok(())
+}
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
-fn transmit<'a, T: Transmitter<’a>>(tx: T, message: &[u8]) -> Result<()> { ... }
+```rust
+{{#include snippet_helpers/function_discipline.rs}}
+# trait Transmitter {}
+# struct Message<'a>(&'a ());
+fn transmit<'a, T: Transmitter>(tx: T, message: &Message<'a>) -> Result<()> {
+    // ...
+#   Ok(())
+}
 ```
 
 ## Unused parameters in default implementations
@@ -79,28 +117,34 @@ Similarly, we could individually annotate each unused parameter, however this wo
 
 ✅ Do this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/function_discipline.rs}}
+# struct Value<'v>(&'v ());
 trait CustomScriptValue<'v> {
     fn at(&self, index: Value<'v>) -> Result<Value<'v>> {
         let _ = index;
-        Err(Error::Unsupported { .. })
+        Err(Error::Unsupported)
     }
 }
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/function_discipline.rs}}
+# struct Value<'v>(&'v ());
 trait CustomScriptValue<'v> {
     fn at(&self, _index: Value<'v>) -> Result<Value<'v>> {
-        Err(Error::Unsupported { .. })
+        Err(Error::Unsupported)
     }
+# }
 
     // OR
 
+# trait CustomScriptValue2<'v> {
     #[allow(unused_variables)]
     fn at(&self, index: Value<'v>) -> Result<Value<'v>> {
-        Err(Error::Unsupported { .. })
+        Err(Error::Unsupported)
     }
 }
 ```
@@ -116,19 +160,19 @@ In typical usage, users of `MyType` shouldn’t need to import `MyTypeBuilder`, 
 use crate::Foo;
 
 let foo = Foo::builder()
-    .bar(bar)
-    // ...
+    .foo("foo")
+    .bar("bar")
     .build()?;
 ```
 
 ⚠️ Avoid this:
 
 ```rust,ignore
-use crate::{Foo, FooBuilder}
+use some_crate::{Foo, FooBuilder}
 
 let foo = FooBuilder::new()
-    .bar(bar)
-    // ...
+    .foo("foo")
+    .bar("bar")
     .build()?;
 ```
 
@@ -137,11 +181,16 @@ let foo = FooBuilder::new()
 In Rust, there are two forms of the builder pattern, depending on the receiver type used.
 Consider the following builder—
 
-```rust,ignore
-let frobnicator = Frobnicator::builder()
+```rust
+{{#include snippet_helpers/function_discipline.rs}}
+# fn snippet() -> Result<()> {
+# type Foo = Arbitrary;
+let frobnicator = Foo::builder()
     .foo("foo")
     .bar("bar")
     .build()?;
+# Ok(())
+# }
 ```
 
 The methods `foo`, `bar` and `build` can either take ownership of `self` or take `&mut self` by value.

--- a/site/src/function-discipline.md
+++ b/site/src/function-discipline.md
@@ -18,7 +18,7 @@ Therefore, do-nothing `match` branches should be written as `.. => {}` rather th
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 fn setup_foo(&self) -> Result<()> {
     match self.foo_type {
         FooType::A => {}
@@ -31,7 +31,7 @@ fn setup_foo(&self) -> Result<()> {
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 fn setup_foo(&self) -> Result<()> {
     match self.foo_type {
         FooType::A => ()
@@ -58,13 +58,13 @@ If a lifetime is present, _always_ communicate that fact (i.e. always prefer `My
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 fn transmit(tx: impl Transmitter<'_>, message: &[u8]) -> Result<()> { ... }
 ```
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 fn transmit<'a, T: Transmitter<’a>>(tx: T, message: &[u8]) -> Result<()> { ... }
 ```
 
@@ -79,7 +79,7 @@ Similarly, we could individually annotate each unused parameter, however this wo
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 trait CustomScriptValue<'v> {
     fn at(&self, index: Value<'v>) -> Result<Value<'v>> {
         let _ = index;
@@ -90,7 +90,7 @@ trait CustomScriptValue<'v> {
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 trait CustomScriptValue<'v> {
     fn at(&self, _index: Value<'v>) -> Result<Value<'v>> {
         Err(Error::Unsupported { .. })
@@ -112,7 +112,7 @@ In typical usage, users of `MyType` shouldn’t need to import `MyTypeBuilder`, 
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 use crate::Foo;
 
 let foo = Foo::builder()
@@ -123,7 +123,7 @@ let foo = Foo::builder()
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 use crate::{Foo, FooBuilder}
 
 let foo = FooBuilder::new()
@@ -137,7 +137,7 @@ let foo = FooBuilder::new()
 In Rust, there are two forms of the builder pattern, depending on the receiver type used.
 Consider the following builder—
 
-```rust
+```rust,ignore
 let frobnicator = Frobnicator::builder()
     .foo("foo")
     .bar("bar")

--- a/site/src/import-discipline.md
+++ b/site/src/import-discipline.md
@@ -20,36 +20,33 @@ There, they should be placed as close as possible to the relevant match, prefera
 
 ✅ Do this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/import_discipline.rs}}
 use some_crate::{SpecificItem1, SpecificItem2};
 use some_other_crate::SpecificItem3;
+use another_crate::{SomeEnum, SomeEnum::*};
 
-// ...
-
-fn some_fn(some_enum: SomeEnum) -> {
-    // ...
-
+fn some_fn(some_enum: SomeEnum) {
     use SomeEnum::*;
-        Variant2 => {...},
+    match some_enum {
+        Variant1 => { /* ... */ }
+        Variant2 => { /* ... */ },
     }
 }
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/import_discipline.rs}}
 use some_crate::*;
 use some_other_crate::prelude::*;
-use another_crate::SomeEnum::*;
+use another_crate::{SomeEnum, SomeEnum::*};
 
-// ...
-
-fn some_fn(some_enum: SomeEnum) -> {
-    // ...
-
-    match {
-        Variant1 => {...},
-        Variant2 => {...},
+fn some_fn(some_enum: SomeEnum) {
+    match some_enum {
+        Variant1 => { /* ... */ }
+        Variant2 => { /* ... */ }
     }
 }
 ```
@@ -83,6 +80,7 @@ use crate::{Error, Result};
 ⚠️ Avoid this:
 
 ```rust,ignore
+{{#include snippet_helpers/import_discipline.rs}}
 use camino::Utf8PathBuf;
 use crate::{Error, Result};
 use std::path::PathBuf;
@@ -97,7 +95,8 @@ If a path contains _n_ parts, merge the first _n-1,_ so that only the final part
 
 ✅ Do this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/import_discipline.rs}}
 use allocative::Allocative;
 use derive_more::Display;
 use starlark::environment::{FrozenModule, Module};
@@ -108,7 +107,8 @@ use starlark_derive::{starlark_value, NoSerialize, Trace};
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/import_discipline.rs}}
 use allocative::Allocative;
 use derive_more::Display;
 use starlark::environment::FrozenModule;

--- a/site/src/import-discipline.md
+++ b/site/src/import-discipline.md
@@ -20,7 +20,7 @@ There, they should be placed as close as possible to the relevant match, prefera
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 use some_crate::{SpecificItem1, SpecificItem2};
 use some_other_crate::SpecificItem3;
 
@@ -37,7 +37,7 @@ fn some_fn(some_enum: SomeEnum) -> {
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 use some_crate::*;
 use some_other_crate::prelude::*;
 use another_crate::SomeEnum::*;
@@ -65,13 +65,13 @@ To clearly delimit whether an import is from the standard library, from a third 
 
 Note that this order follows the currently-unstable `rustfmt` option—
 
-```
+```toml
 import_group = "StdExternCrate"
 ```
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 use std::path::PathBuf;
 
 use camino::Utf8PathBuf;
@@ -82,7 +82,7 @@ use crate::{Error, Result};
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 use camino::Utf8PathBuf;
 use crate::{Error, Result};
 use std::path::PathBuf;
@@ -97,7 +97,7 @@ If a path contains _n_ parts, merge the first _n-1,_ so that only the final part
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 use allocative::Allocative;
 use derive_more::Display;
 use starlark::environment::{FrozenModule, Module};
@@ -108,7 +108,7 @@ use starlark_derive::{starlark_value, NoSerialize, Trace};
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 use allocative::Allocative;
 use derive_more::Display;
 use starlark::environment::FrozenModule;
@@ -130,7 +130,7 @@ When importing from a child module `foo`, always `use self::foo` as this avoids 
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 mod foo;
 mod bar;
 
@@ -140,7 +140,7 @@ pub use self::bar::Bar;
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 mod foo;
 mod bar;
 

--- a/site/src/naming-discipline.md
+++ b/site/src/naming-discipline.md
@@ -49,7 +49,7 @@ When matching structs and struct-like enum variants, try to use the original fie
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 if let Some(response) = response { ... }
 if let Some(response) = event.response { ... }
 if let Some(event_response) = event.response { ... }
@@ -71,7 +71,7 @@ match state {
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 if let Some(r) = response { ... }
 if let Some(r) = event.response { ... }
 if let Some(er) = event.response { ... }
@@ -107,7 +107,7 @@ Single-letter lifetime names should generally be avoided.
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 struct ASTQueryMatch<'cursor, 'tree> { .. }
 
 struct Value<'h> { .. }
@@ -115,7 +115,7 @@ struct Value<'h> { .. }
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 struct ASTQueryMatch<'a, 'b> { .. }
 
 struct Value<'value> { .. }
@@ -128,7 +128,7 @@ This `MyTypeBuilder` must also have a fallible `.build()` method, which returns 
 
 Typical usage is hence—
 
-```rust
+```rust,ignore
 let foo = Foo::builder()
     .bar(bar)
     // ...

--- a/site/src/naming-discipline.md
+++ b/site/src/naming-discipline.md
@@ -49,38 +49,74 @@ When matching structs and struct-like enum variants, try to use the original fie
 
 ✅ Do this:
 
-```rust,ignore
-if let Some(response) = response { ... }
-if let Some(response) = event.response { ... }
-if let Some(event_response) = event.response { ... }
+```rust
+{{#include snippet_helpers/naming_discipline.rs}}
+# let response = Some(());
+if let Some(response) = response { /* ... */ }
+#
+# let event = Event { response: None };
+if let Some(response) = event.response { /* ... */ }
+if let Some(event_response) = event.response { /* ... */ }
 
+# impl File {
+#   fn f(self) {
 let Self { name, path } = self;
+#   }
+# }
 
+# use std::fs;
+# type Workload = ();
 enum State {
     Reading(fs::File),
     Evaluating {
         workload: Workload,
-        ...
+#       other_fields: (),
+        /* ... */
     }
 }
+# let state = State::Evaluating {
+#     workload: (),
+#     other_fields: ()
+# };
 match state {
-    State::Reading(file) => {...}
-    State::Evaluating{ workload, .. } => {...}
+    State::Reading(file) => { /* ... */ }
+    State::Evaluating{ workload, .. } => { /* ... */ }
 }
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
-if let Some(r) = response { ... }
-if let Some(r) = event.response { ... }
-if let Some(er) = event.response { ... }
+```rust
+{{#include snippet_helpers/naming_discipline.rs}}
+# let response = Some(());
+if let Some(r) = response { /* ... */ }
+#
+# let event = Event { response: None };
+if let Some(r) = event.response { /* ... */ }
+if let Some(er) = event.response { /* ... */ }
 
+# impl File {
+#   fn f(self) {
 let Self { name: some_name, path: name } = self;
+#   }
+# }
 
+# use std::fs;
+# type Workload = ();
+# enum State {
+#     Reading(fs::File),
+#     Evaluating {
+#         workload: Workload,
+#         other_fields: (),
+#     }
+# }
+# let state = State::Evaluating {
+#     workload: (),
+#     other_fields: ()
+# };
 match state {
-    State::Reading(data_source) => {...}
-    State::Evaluating{ workload: to_eval, .. } => {...}
+    State::Reading(data_source) => { /* ... */ }
+    State::Evaluating{ workload: to_eval, .. } => { /* ... */ }
 }
 ```
 
@@ -107,18 +143,30 @@ Single-letter lifetime names should generally be avoided.
 
 ✅ Do this:
 
-```rust,ignore
-struct ASTQueryMatch<'cursor, 'tree> { .. }
+```rust
+struct ASTQueryMatch<'cursor, 'tree> {
+    /* ... */
+# ignore: std::marker::PhantomData<&'cursor &'tree ()>,
+}
 
-struct Value<'h> { .. }
+struct Value<'h> {
+    /* ... */
+# ignore: std::marker::PhantomData<&'h ()>,
+}
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
-struct ASTQueryMatch<'a, 'b> { .. }
+```rust
+struct ASTQueryMatch<'a, 'b> {
+    /* ... */
+# ignore: std::marker::PhantomData<&'a &'b ()>,
+}
 
-struct Value<'value> { .. }
+struct Value<'value> {
+    /* ... */
+# ignore: std::marker::PhantomData<&'value ()>,
+}
 ```
 
 ## Builder naming
@@ -128,11 +176,17 @@ This `MyTypeBuilder` must also have a fallible `.build()` method, which returns 
 
 Typical usage is hence—
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/naming_discipline.rs}}
+# fn snippet() -> Result<()> {
+# type Foo = Arbitrary;
+# let bar = Arbitrary;
 let foo = Foo::builder()
     .bar(bar)
     // ...
     .build()?;
+# Ok(())
+# }
 ```
 
 [dictionary]: https://www.dictionary.com/

--- a/site/src/naming-discipline.md
+++ b/site/src/naming-discipline.md
@@ -146,12 +146,12 @@ Single-letter lifetime names should generally be avoided.
 ```rust
 struct ASTQueryMatch<'cursor, 'tree> {
     /* ... */
-# ignore: std::marker::PhantomData<&'cursor &'tree ()>,
+# ignore: &'cursor &'tree (),
 }
 
 struct Value<'h> {
     /* ... */
-# ignore: std::marker::PhantomData<&'h ()>,
+# ignore: &'h (),
 }
 ```
 
@@ -160,12 +160,12 @@ struct Value<'h> {
 ```rust
 struct ASTQueryMatch<'a, 'b> {
     /* ... */
-# ignore: std::marker::PhantomData<&'a &'b ()>,
+# ignore: &'a &'b (),
 }
 
 struct Value<'value> {
     /* ... */
-# ignore: std::marker::PhantomData<&'value ()>,
+# ignore: &'value (),
 }
 ```
 

--- a/site/src/ordering-discipline.md
+++ b/site/src/ordering-discipline.md
@@ -9,7 +9,7 @@ In this way, lower-level implementation details are hidden from the reader until
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 impl Foo {
     pub fn some_func(&self) {
         self.some_helper_func();
@@ -23,7 +23,7 @@ impl Foo {
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 impl Foo {
     fn some_helper_func(&self) {
         // ...
@@ -105,7 +105,7 @@ The reader is more likely to be looking at the entire struct rather than just on
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 struct ScriptExecutionContext<'h, T> {
     pub user_data: T,
 
@@ -119,7 +119,7 @@ struct ScriptExecutionContext<'h, T> {
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 struct ScriptExecutionContext<'h, T> {
     stack: Vec<StackFrame>,
     pub(crate) global_vars: BTreeMap<String, Value<'h>>,

--- a/site/src/ordering-discipline.md
+++ b/site/src/ordering-discipline.md
@@ -9,7 +9,9 @@ In this way, lower-level implementation details are hidden from the reader until
 
 ✅ Do this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/ordering_discipline.rs}}
+# type Foo = Arbitrary;
 impl Foo {
     pub fn some_func(&self) {
         self.some_helper_func();
@@ -23,7 +25,9 @@ impl Foo {
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/ordering_discipline.rs}}
+# type Foo = Arbitrary;
 impl Foo {
     fn some_helper_func(&self) {
         // ...
@@ -105,7 +109,10 @@ The reader is more likely to be looking at the entire struct rather than just on
 
 ✅ Do this:
 
-```rust,ignore
+```rust
+# use std::collections::BTreeMap;
+# type StackFrame = ();
+# type Value<'h> = &'h ();
 struct ScriptExecutionContext<'h, T> {
     pub user_data: T,
 
@@ -119,7 +126,10 @@ struct ScriptExecutionContext<'h, T> {
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
+# use std::collections::BTreeMap;
+# type StackFrame = ();
+# type Value<'h> = &'h ();
 struct ScriptExecutionContext<'h, T> {
     stack: Vec<StackFrame>,
     pub(crate) global_vars: BTreeMap<String, Value<'h>>,

--- a/site/src/pattern-matching-discipline.md
+++ b/site/src/pattern-matching-discipline.md
@@ -8,7 +8,9 @@ This in turn will draw the attention of the next maintainer and help them correc
 
 ✅ Do this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/pattern_matching_discipline.rs}}
+# use std::cmp::Ordering;
 impl Ord for MyStruct {
     fn cmp(&self, other: &Self) -> Ordering {
         let Self {
@@ -20,18 +22,20 @@ impl Ord for MyStruct {
             fields: _,
         } = self;
         (my, thing, with, some)
-            .cmp(&(other.my, other.thing, other.with, other.some))
+            .cmp(&(&other.my, &other.thing, &other.with, &other.some))
     }
 }
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/pattern_matching_discipline.rs}}
+# use std::cmp::Ordering;
 impl Ord for MyStruct {
     fn cmp(&self, other: &Self) -> Ordering {
         (self.my, self.thing, self.with, self.some)
-            .cmp(&(other.my, other.type, other.with, other.some))
+            .cmp(&(other.my, other.thing, other.with, other.some))
     }
 }
 ```
@@ -43,14 +47,18 @@ Although it may seem convenient, it ultimately harms readability—it is clearer
 
 ✅ Do this:
 
-```rust,ignore
+```rust
+# [0].iter()
     .map(|x| *x)
+# ;
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
+# [0].iter()
     .map(|&x| x)
+# ;
 ```
 
 ## Avoid numeric tuple-indexing
@@ -61,7 +69,8 @@ Note that this advice does not apply in the `impl` blocks of newtype-pattern str
 
 ✅ Do this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/pattern_matching_discipline.rs}}
 fn line_through(point1: (f64, f64), point2: (f64, f64)) -> Line {
 	let (x1, y1) = point1;
 	let (x2, y2) = point2;
@@ -76,7 +85,8 @@ fn line_through(point1: (f64, f64), point2: (f64, f64)) -> Line {
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/pattern_matching_discipline.rs}}
 fn line_through(point1: (f64, f64), point2: (f64, f64)) -> Line {
 	let gradient = (point2.1 - point1.1) / (point2.0 - point1.0);
 	let y_intercept = point1.1 - gradient * point1.0;
@@ -98,21 +108,25 @@ Note that this guidance does not apply to closures, which are commonly used as s
 
 ✅ Do this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/pattern_matching_discipline.rs}}
 impl Server {
     fn new(config: ServerConfig) -> Result<Self> {
-        let Config { db_path, working_path } = config;
-        // ...
+        let ServerConfig { db_path, working_path } = config;
+        /* ... */
+#       Ok(Server)
     }
 }
 ```
 
 ⚠️ Avoid this:
 
-```rust,ignore
+```rust
+{{#include snippet_helpers/pattern_matching_discipline.rs}}
 impl Server {
     fn new(ServerConfig { db_path, working_path }: ServerConfig) -> Result<Self> {
-        // ...
+        /* ... */
+#       Ok(Server)
     }
 }
 ```

--- a/site/src/pattern-matching-discipline.md
+++ b/site/src/pattern-matching-discipline.md
@@ -34,8 +34,8 @@ impl Ord for MyStruct {
 # use std::cmp::Ordering;
 impl Ord for MyStruct {
     fn cmp(&self, other: &Self) -> Ordering {
-        (self.my, self.thing, self.with, self.some)
-            .cmp(&(other.my, other.thing, other.with, other.some))
+        (&self.my, &self.thing, &self.with, &self.some)
+            .cmp(&(&other.my, &other.thing, &other.with, &other.some))
     }
 }
 ```

--- a/site/src/pattern-matching-discipline.md
+++ b/site/src/pattern-matching-discipline.md
@@ -8,7 +8,7 @@ This in turn will draw the attention of the next maintainer and help them correc
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 impl Ord for MyStruct {
     fn cmp(&self, other: &Self) -> Ordering {
         let Self {
@@ -27,7 +27,7 @@ impl Ord for MyStruct {
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 impl Ord for MyStruct {
     fn cmp(&self, other: &Self) -> Ordering {
         (self.my, self.thing, self.with, self.some)
@@ -43,13 +43,13 @@ Although it may seem convenient, it ultimately harms readability—it is clearer
 
 ✅ Do this:
 
-```rust
+```rust,ignore
     .map(|x| *x)
 ```
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
     .map(|&x| x)
 ```
 
@@ -61,7 +61,7 @@ Note that this advice does not apply in the `impl` blocks of newtype-pattern str
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 fn line_through(point1: (f64, f64), point2: (f64, f64)) -> Line {
 	let (x1, y1) = point1;
 	let (x2, y2) = point2;
@@ -76,7 +76,7 @@ fn line_through(point1: (f64, f64), point2: (f64, f64)) -> Line {
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 fn line_through(point1: (f64, f64), point2: (f64, f64)) -> Line {
 	let gradient = (point2.1 - point1.1) / (point2.0 - point1.0);
 	let y_intercept = point1.1 - gradient * point1.0;
@@ -98,7 +98,7 @@ Note that this guidance does not apply to closures, which are commonly used as s
 
 ✅ Do this:
 
-```rust
+```rust,ignore
 impl Server {
     fn new(config: ServerConfig) -> Result<Self> {
         let Config { db_path, working_path } = config;
@@ -109,7 +109,7 @@ impl Server {
 
 ⚠️ Avoid this:
 
-```rust
+```rust,ignore
 impl Server {
     fn new(ServerConfig { db_path, working_path }: ServerConfig) -> Result<Self> {
         // ...

--- a/site/src/snippet_helpers/code_discipline.rs
+++ b/site/src/snippet_helpers/code_discipline.rs
@@ -1,0 +1,57 @@
+{{#include error_handling.rs}}
+#
+# struct Arbitrary;
+# impl Arbitrary {
+#     fn new() -> Self {
+#         Self
+#     }
+#
+#     fn something_else(self) -> Self {
+#         self
+#     }
+#
+#     fn another_thing(self) -> Self {
+#         self
+#     }
+#
+#     fn chained_with_something_else(self) -> Result<Self> {
+#         Ok(self)
+#     }
+#
+#     fn format_as(self, fmt: &str) -> String {
+#         String::new()
+#     }
+# }
+#
+# fn some_long_computation() -> Result<Arbitrary> {
+#     Ok(Arbitrary)
+# }
+#
+# fn some_other_long_computation() -> Arbitrary {
+#     Arbitrary
+# }
+#
+# struct Input;
+# trait Responder {
+#     type Response;
+#     type Err;
+#     fn respond(&self, input: Input) -> std::result::Result<Self::Response, Self::Err>;
+# }
+#
+#
+# struct Message;
+#
+# impl Message {
+#     fn text(&self) {}
+# }
+#
+#
+# struct Log {
+#     log_file_path: String,
+# }
+#
+# impl Log {
+#     async fn transmit_log(&self, _: &str) -> Result<usize> {
+#         Ok(0)
+#     }
+# }

--- a/site/src/snippet_helpers/comment_discipline.rs
+++ b/site/src/snippet_helpers/comment_discipline.rs
@@ -1,0 +1,3 @@
+{{#include error_handling.rs}}
+#
+# struct Arbitrary;

--- a/site/src/snippet_helpers/cosmetic_discipline.rs
+++ b/site/src/snippet_helpers/cosmetic_discipline.rs
@@ -1,0 +1,32 @@
+{{#include error_handling.rs}}
+# struct Arbitrary;
+#
+# impl Arbitrary {
+#     fn is_valid(&self) -> bool {
+#         true
+#     }
+# }
+#
+# impl std::ops::Add for Arbitrary {
+#     type Output = Self;
+#
+#     fn add(self, _: Self) -> Self {
+#         Self
+#     }
+# }
+#
+# impl std::fmt::Display for Arbitrary {
+#     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+#         write!(f, "Arbitrary")
+#     }
+# }
+#
+# fn foo() -> Arbitrary {
+#     Arbitrary
+# }
+# fn bar() -> Arbitrary {
+#     Arbitrary
+# }
+# fn baz() -> Arbitrary {
+#     Arbitrary
+# }

--- a/site/src/snippet_helpers/error_and_panic_discipline.rs
+++ b/site/src/snippet_helpers/error_and_panic_discipline.rs
@@ -1,0 +1,11 @@
+{{#include error_handling.rs}}
+#
+# mod url {
+#     pub struct Url;
+#
+#     impl Url {
+#         pub fn parse(_: &str) -> std::result::Result<Self, Box<dyn std::error::Error>> {
+#             Ok(Self)
+#         }
+#     }
+# }

--- a/site/src/snippet_helpers/error_handling.rs
+++ b/site/src/snippet_helpers/error_handling.rs
@@ -1,0 +1,15 @@
+# type Result<T> = std::result::Result<T, Error>;
+#
+# enum Error {
+#     Invalid,
+#     Unknown(Box<dyn std::error::Error>),
+# }
+#
+# impl<E> From<E> for Error
+# where
+#     E: std::error::Error + 'static,
+# {
+#     fn from(err: E) -> Self {
+#         Error::Unknown(Box::new(err))
+#     }
+# }

--- a/site/src/snippet_helpers/error_handling.rs
+++ b/site/src/snippet_helpers/error_handling.rs
@@ -7,6 +7,7 @@
 #         env_var: &'static str,
 #         source: Box<dyn std::error::Error>,
 #     },
+#     Unsupported,
 #     Unknown(Box<dyn std::error::Error>),
 # }
 #

--- a/site/src/snippet_helpers/error_handling.rs
+++ b/site/src/snippet_helpers/error_handling.rs
@@ -2,6 +2,7 @@
 #
 # enum Error {
 #     Invalid,
+#     NetworkUnavailable,
 #     Unknown(Box<dyn std::error::Error>),
 # }
 #

--- a/site/src/snippet_helpers/error_handling.rs
+++ b/site/src/snippet_helpers/error_handling.rs
@@ -3,6 +3,10 @@
 # enum Error {
 #     Invalid,
 #     NetworkUnavailable,
+#     MalformedEnvUrl {
+#         env_var: &'static str,
+#         source: Box<dyn std::error::Error>,
+#     },
 #     Unknown(Box<dyn std::error::Error>),
 # }
 #

--- a/site/src/snippet_helpers/function_discipline.rs
+++ b/site/src/snippet_helpers/function_discipline.rs
@@ -23,3 +23,33 @@
 #         Ok(self)
 #     }
 # }
+
+mod some_crate {
+    pub struct Foo;
+
+    impl Foo {
+        pub fn builder() -> FooBuilder {
+            FooBuilder
+        }
+    }
+
+    pub struct FooBuilder;
+
+    impl FooBuilder {
+        pub fn new() -> Self {
+            Self
+        }
+
+        pub fn foo(self, _: &'static str) -> Self {
+            self
+        }
+
+        pub fn bar(self, _: &'static str) -> Self {
+            self
+        }
+
+        pub fn build(self) -> std::result::Result<Foo, Box<dyn std::error::Error>> {
+            Ok(Foo)
+        }
+    }
+}

--- a/site/src/snippet_helpers/function_discipline.rs
+++ b/site/src/snippet_helpers/function_discipline.rs
@@ -1,0 +1,25 @@
+{{#include error_handling.rs}}
+#
+# struct Arbitrary;
+#
+# impl Arbitrary {
+#     fn new() -> Self {
+#         Self
+#     }
+#
+#     fn builder() -> Self {
+#         Self
+#     }
+#
+#     fn foo(self, _: &str) -> Self {
+#         self
+#     }
+#
+#     fn bar(self, _: &str) -> Self {
+#         self
+#     }
+#
+#     fn build(self) -> Result<Self> {
+#         Ok(self)
+#     }
+# }

--- a/site/src/snippet_helpers/import_discipline.rs
+++ b/site/src/snippet_helpers/import_discipline.rs
@@ -1,40 +1,40 @@
 {{#include error_handling.rs}}
-# 
+#
 # mod some_crate {
 #     pub struct SpecificItem1;
 #     pub struct SpecificItem2;
 # }
-# 
+#
 # mod some_other_crate {
 #     pub mod prelude {}
 #     pub struct SpecificItem3;
 # }
-# 
+#
 # mod another_crate {
 #     pub enum SomeEnum {
 #         Variant1,
 #         Variant2,
 #     }
 # }
-# 
+#
 # mod allocative {
 #     pub struct Allocative;
 # }
-# 
+#
 # mod derive_more {
 #     pub struct Display;
 # }
-# 
+#
 # mod starlark {
 #     pub mod environment {
 #         pub struct FrozenModule;
 #         pub struct Module;
 #     }
-# 
+#
 #     pub mod eval {
 #         pub struct Evaluator;
 #     }
-# 
+#
 #     pub mod values {
 #         pub struct AllocValue;
 #         pub struct Freeze;
@@ -43,7 +43,7 @@
 #         pub struct ValueLike;
 #     }
 # }
-# 
+#
 # mod starlark_derive {
 #     pub fn starlark_value() {}
 #     pub struct NoSerialize;

--- a/site/src/snippet_helpers/import_discipline.rs
+++ b/site/src/snippet_helpers/import_discipline.rs
@@ -1,0 +1,51 @@
+{{#include error_handling.rs}}
+# 
+# mod some_crate {
+#     pub struct SpecificItem1;
+#     pub struct SpecificItem2;
+# }
+# 
+# mod some_other_crate {
+#     pub mod prelude {}
+#     pub struct SpecificItem3;
+# }
+# 
+# mod another_crate {
+#     pub enum SomeEnum {
+#         Variant1,
+#         Variant2,
+#     }
+# }
+# 
+# mod allocative {
+#     pub struct Allocative;
+# }
+# 
+# mod derive_more {
+#     pub struct Display;
+# }
+# 
+# mod starlark {
+#     pub mod environment {
+#         pub struct FrozenModule;
+#         pub struct Module;
+#     }
+# 
+#     pub mod eval {
+#         pub struct Evaluator;
+#     }
+# 
+#     pub mod values {
+#         pub struct AllocValue;
+#         pub struct Freeze;
+#         pub struct ProvidesStaticType;
+#         pub struct StarlarkValue;
+#         pub struct ValueLike;
+#     }
+# }
+# 
+# mod starlark_derive {
+#     pub fn starlark_value() {}
+#     pub struct NoSerialize;
+#     pub struct Trace;
+# }

--- a/site/src/snippet_helpers/naming_discipline.rs
+++ b/site/src/snippet_helpers/naming_discipline.rs
@@ -1,0 +1,25 @@
+{{#include error_handling.rs}}
+# struct Arbitrary;
+#
+# impl Arbitrary {
+#     fn builder() -> Self {
+#         Self
+#     }
+#
+#     fn bar(self, _: Self) -> Self {
+#         Self
+#     }
+#
+#     fn build(self) -> Result<Self> {
+#         Ok(Self)
+#     }
+# }
+#
+# struct Event {
+#     response: Option<()>,
+# }
+#
+# struct File {
+#     name: (),
+#     path: (),
+# }

--- a/site/src/snippet_helpers/ordering_discipline.rs
+++ b/site/src/snippet_helpers/ordering_discipline.rs
@@ -1,0 +1,3 @@
+{{#include error_handling.rs}}
+#
+# struct Arbitrary;

--- a/site/src/snippet_helpers/pattern_matching_discipline.rs
+++ b/site/src/snippet_helpers/pattern_matching_discipline.rs
@@ -1,0 +1,22 @@
+{{#include error_handling.rs}}
+#
+# #[derive(Eq, PartialEq, PartialOrd)]
+# struct MyStruct {
+#     my: (),
+#     thing: (),
+#     with: (),
+#     some: (),
+#     unused: (),
+#     fields: (),
+# }
+#
+# struct Line {
+#     gradient: f64,
+#     y_intercept: f64,
+# }
+#
+# struct Server;
+# struct ServerConfig {
+#     db_path: (),
+#     working_path: (),
+# }

--- a/site/src/snippet_helpers/pattern_matching_discipline.rs
+++ b/site/src/snippet_helpers/pattern_matching_discipline.rs
@@ -2,12 +2,12 @@
 #
 # #[derive(Eq, PartialEq, PartialOrd)]
 # struct MyStruct {
-#     my: (),
-#     thing: (),
-#     with: (),
-#     some: (),
-#     unused: (),
-#     fields: (),
+#     my: String,
+#     thing: String,
+#     with: String,
+#     some: String,
+#     unused: String,
+#     fields: String,
 # }
 #
 # struct Line {

--- a/site/src/structural-discipline.md
+++ b/site/src/structural-discipline.md
@@ -26,7 +26,7 @@ When declaring a module `foo` which comprises multiple files, Rust allows two di
 
 Firstly, all files can be grouped into a single directory containing a `mod.rs`—
 
-```
+```ignore
 foo/
 ├── mod.rs
 ├── file_in_foo.rs
@@ -35,7 +35,7 @@ foo/
 
 Secondly, all files can be grouped into a single directory, except for the module root which is stored next to the directory and shares its name—
 
-```
+```ignore
 foo.rs
 foo/
 ├── file_in_foo.rs


### PR DESCRIPTION
This PR adds `mdbook test` to the CI and ensures that all\* snippets pass tests as suggested in #7.

\*All snippets are tested except those which include:
- `use crate::...` as items cannot be inserted into the `crate` namespace from tests
- `#[derive(NonStandardTrait)]` with custom attributes as the custom attributes could not be spoofed
