### PR TITLE
Simplify derive-ordering examples

### DIFF
--- a/site/src/ordering-discipline.md
+++ b/site/src/ordering-discipline.md
@@ -72,6 +72,24 @@ Derived items should be ordered as follows:
 - Standard library derives, ordered lexicographically (these form a common expectation for basic behaviour and missing items are surprising)
 - Third party items, ordered lexicographically
 
+✅ Do this:
+
+```rust,ignore
+use external_crate::{Bar, Foo};
+
+#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Bar, Foo)]
+struct MyType;
+```
+
+⚠️ Avoid this:
+
+```rust,ignore
+use external_crate::{Bar, Foo};
+
+#[derive(Foo, Clone, Copy, PartialEq, Eq, Hash, Debug, Ord, PartialOrd, Bar)]
+struct MyType;
+```
+
 ## Declaration ordering
 
 Rust provides several different types of declaration and where these are declared consecutively in the same block, they should be ordered for visual consistency.

--- a/site/src/ordering-discipline.md
+++ b/site/src/ordering-discipline.md
@@ -68,15 +68,9 @@ The `impl` blocks in the same file for `MyTrait` should be ordered as follows:
 Put all derive items in a single `#[derive(...)]` (the formatter will preserve readability by introducing line-breaks as it deems fit).
 Derived items should be ordered as follows:
 
-- `Copy`
-- `Clone`
-- `Debug`
-- `PartialEq`
-- `Eq`
-- `PartialOrd`
-- `Ord`
-- Other standard traits, ordered lexicographically
-- Third party traits, ordered lexicographically
+- `Copy` should come first (this has the most surprising effect on how the consumer will interact with values of the given type)
+- Standard library derives, ordered lexicographically (these form a common expectation for basic behaviour and missing items are surprising)
+- Third party items, ordered lexicographically
 
 ## Declaration ordering
 

--- a/site/src/ordering-discipline.md
+++ b/site/src/ordering-discipline.md
@@ -69,7 +69,7 @@ Put all derive items in a single `#[derive(...)]` (the formatter will preserve r
 Derived items should be ordered as follows:
 
 - `Copy` should come first (this has the most surprising effect on how the consumer will interact with values of the given type)
-- Standard library derives, ordered lexicographically (these form a common expectation for basic behaviour and missing items are surprising)
+- Standard library items, ordered lexicographically (these form a common expectation for basic behaviour and missing items are surprising)
 - Third party items, ordered lexicographically
 
 ✅ Do this:


### PR DESCRIPTION
This PR resolves the over-complex derive-ordering advice as noted in #2
