### PR TITLE
Remove reference to `lazy_static`

### DIFF
--- a/site/src/ordering-discipline.md
+++ b/site/src/ordering-discipline.md
@@ -87,7 +87,6 @@ Declarations should be ordered as follows:
 
 - `const`
 - `static`
-- `lazy_static!`
 - `let`
 - `let mut`
 


### PR DESCRIPTION
This PR removes a stray reference to `lazy_static` which should be avoided in new projects since the stabilisation of `std::sync::LazyLock`, thus allowing us to remove a dependency
