### PR TITLE
FIX [import]: align example with guidance on Enum::*

### DIFF
--- a/site/src/import-discipline.md
+++ b/site/src/import-discipline.md
@@ -24,7 +24,7 @@ The only exception to these rules is that in the context of a unit test module, 
 {{#include snippet_helpers/import_discipline.rs}}
 use some_crate::{SpecificItem1, SpecificItem2};
 use some_other_crate::SpecificItem3;
-use another_crate::{SomeEnum, SomeEnum::*};
+use another_crate::SomeEnum;
 
 fn some_fn(some_enum: SomeEnum) -> SomeEnum {
     use SomeEnum as Se;


### PR DESCRIPTION
The guideline advises against using "use Enum::*", but the good example was not aligned with it.

This PR removes the glob import, matching the recommended style.

Thanks for your work on this book, it's a great resource !