### PR TITLE
Tell GitHub that the snippet helpers are not RenderScript

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Tell GitHub that the snippet helpers are not RenderScript
+snippet_helpers/*.rs linguist-language=Text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Tell GitHub that the snippet helpers are not RenderScript
-snippet_helpers/*.rs linguist-language=Text
+**/snippet_helpers/*.rs linguist-language=Text


### PR DESCRIPTION
While searching for RenderScript examples with `language:RenderScript`, this project popped up. This PR should make the language statistics on GitHub a little more accurate.

Since these snippets are meant to be includes for documentation, I figured that `Text` (aka plain text) was a reasonable language. Of course, it could be `Rust`, too.